### PR TITLE
Resolves #10: Fixes typos and improves formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ Also, a message queue will be used to communicate logging information from the s
 ```
 Thus we have sent the message `Looked up cars` time stamped with the time the message is created, 01:15:35 PM on January 4, 2019.
 
-Write a RESTful web application that exposes the following end points
-Expose the following RESTful end points
+Write a RESTful web application that exposes the following end points:
 ## GET
 /cars/id/{id}  
 returns the car based of of id

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Tells us that a 1 Series BMW model car was produced in year 2010.
 The agreement between the client and server is that JSON objects will be used and each JSON object exchanged will follow the format   
 ```json
 {   
-    "id":1,  
+    "id": 1,  
     "year": 2010,    
     "brand": "BMW",    
     "model": "1 Series"    
@@ -28,7 +28,7 @@ So, no additional link data is necessary in the JSON object. Also notice the add
 Also, a message queue will be used to communicate logging information from the server. Not all transactions will be logged. When a logging message is sent to the message queue, the JSON object will be something like:  
 ```json
 {  
-    "mgs":"Looked up cars",  
+    "msg": "Looked up cars",  
     "date": "2019-01-04 01:15:35 PM"  
 }  
 ```

--- a/README.md
+++ b/README.md
@@ -5,26 +5,33 @@ Many different car models are produced each year. Keeping track of these models 
 # Instructions
 
 The cars.json file contains the cars to use in your application. They are in a JSON format with the fields: Year, Brand Model. So for example:  
+```json
 {  
     "year": 2010,  
     "brand": "BMW",  
     "model": "1 Series"  
-}  
+} 
+``` 
 Tells us that a 1 Series BMW model car was produced in year 2010.
 
 The agreement between the client and server is that JSON objects will be used and each JSON object exchanged will follow the format   
-{   "id":1,  
+```json
+{   
+    "id":1,  
     "year": 2010,    
     "brand": "BMW",    
     "model": "1 Series"    
 }  
+```
 So, no additional link data is necessary in the JSON object. Also notice the addition of the internally generated and maintained ID field. The ID will be created and used by the application but not be loaded through the JSON file.
 
 Also, a message queue will be used to communicate logging information from the server. Not all transactions will be logged. When a logging message is sent to the message queue, the JSON object will be something like:  
+```json
 {  
     "mgs":"Looked up cars"  
     "date""2019-01-04 01:15:35 PM"  
 }  
+```
 Thus we have sent the message Looked up cars time stamped (the time the message is created) 01:14:15 P on January 4, 2019.
 
 Write a RESTful web application that exposes the following end points

--- a/README.md
+++ b/README.md
@@ -30,19 +30,19 @@ Thus we have sent the message Looked up cars time stamped (the time the message 
 Write a RESTful web application that exposes the following end points
 Expose the following RESTful end points
 ## GET
-/cars/id/{id}
+/cars/id/{id}  
 returns the car based of of id
 
-/cars/year/{year}
+/cars/year/{year}  
 returns a list of cars of that year model
 
-/cars/brand/{brand}
-returns a list of cars of that brand
+/cars/brand/{brand}  
+returns a list of cars of that brand  
 This gets logged with a message of "search for {brand}". So put the brand of the car that was searched in the message itself.
 
 ## POST
 /cars/upload  
-loads multiple sets of data from the RequestBody
+loads multiple sets of data from the RequestBody  
 This gets logged with a message of "Data loaded"
 
 ## DELETE

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ returns a list of cars of that year model
 
 /cars/brand/{brand}
 returns a list of cars of that brand
-This gest logged with a message of "search for {brand}". So put the brand of the car that was searched in the message itself.
+This gets logged with a message of "search for {brand}". So put the brand of the car that was searched in the message itself.
 
 ## POST
 /cars/upload  

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Many different car models are produced each year. Keeping track of these models 
 
 # Instructions
 
-The cars.json file contains the cars to use in your application. They are in a JSON format with the fields: Year, Brand Model. So for example:  
+The cars.json file contains the cars to use in your application. They are in a JSON format with the fields: `Year`, `Brand`, and `Model`. So, for example:  
 ```json
 {  
     "year": 2010,  
@@ -28,11 +28,11 @@ So, no additional link data is necessary in the JSON object. Also notice the add
 Also, a message queue will be used to communicate logging information from the server. Not all transactions will be logged. When a logging message is sent to the message queue, the JSON object will be something like:  
 ```json
 {  
-    "mgs":"Looked up cars"  
-    "date""2019-01-04 01:15:35 PM"  
+    "mgs":"Looked up cars",  
+    "date": "2019-01-04 01:15:35 PM"  
 }  
 ```
-Thus we have sent the message Looked up cars time stamped (the time the message is created) 01:14:15 P on January 4, 2019.
+Thus we have sent the message `Looked up cars` time stamped with the time the message is created, 01:15:35 PM on January 4, 2019.
 
 Write a RESTful web application that exposes the following end points
 Expose the following RESTful end points


### PR DESCRIPTION
Resolves #10 and then a little.
- Fixes confusing typo `gest -> gets`
- Fixes confusing and inconsistent lack of line-breaks on some lines
- Uses code blocks for JSON
- Fixes JSON missing comma and colon
- Uses inline code for emphasis on code-related things
- Fixes time to be the same as in the example
- Adds commas where needed for clarity
- Removes unnecessarily repetitive line
- Fixes typo in JSON, `mgs -> msg`